### PR TITLE
Filtering logs via log level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
   - 10
   - 9
   - 8
-  - 6
 install:
   - yarn
 script:

--- a/README.md
+++ b/README.md
@@ -23,17 +23,18 @@ Example:
 ```js
 const Logger = require('@naturacosmeticos/clio-nodejs-logger');
 const uuid = require('uuid/v4');
-const context = {
-  requestId: uuid(),
-  // Any additional info that you want to include with every record
-};
-const namespace = '';
-const logger = new Logger(context, namespace);
 
-const appLogger = logger.createChildLogger('app');
+const appLogger = new Logger({
+  context: {
+    requestId: uuid(),
+    // Any additional info that you want to include with every record
+  },
+  namespace: 'appLogger'
+})
+
 appLogger.info('Starting application', { someData });
 
-const httpLogger = logger.createChildLogger('http');
+const httpLogger = appLogger.createChildLogger('http');
 httpLogger.info('Start GET on /', { someData });
 httpLogger.error('Error processing GET on /', { someData });
 ```
@@ -44,7 +45,7 @@ By default all log namespaces are disabled. To enable them you must pass the
 This variable follows the same semantics as the
 [debug](http://npmjs.com/package/debug) library on npm.
 
-By default the log object will be truncated* when it exceed 7kb and the log level is not debug. If you need to increase this limit, you can set environment variable `LOG_LIMIT` with the value in bytes (i.e.: 10000 = 10kb) or pass the limit in the Logger constructor: `new Logger(context, namespace, 10000);`
+By default the log object will be truncated* when it exceed 7kb and the log level is not debug. If you need to increase this limit, you can set environment variable `LOG_LIMIT` with the value in bytes (i.e.: 10000 = 10kb) or pass the limit in the Logger constructor: `new Logger({ ...options, logLimit: 10000 });`
 
 _&ast; when the log object is truncated only the following attributes are logged: `context`, `level`, `message` and `timestamp`._
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ httpLogger.error('Error processing GET on /', { someData });
 By default all log namespaces are disabled. To enable them you must pass the
 `LOG_NAMESPACES` environment variable with the logging patterns you want to show.
 
+If you need to filter your logs by level you can either use `LOG_LEVEL` environment variable or pass the option into
+its contructor when instantiating `new Logger({ ...options, logLevel: 'info' })`.
+
 This variable follows the same semantics as the
 [debug](http://npmjs.com/package/debug) library on npm.
 
@@ -49,7 +52,7 @@ By default the log object will be truncated* when it exceed 7kb and the log leve
 
 _&ast; when the log object is truncated only the following attributes are logged: `context`, `level`, `message` and `timestamp`._
 
-More details of how use this lib can be found in the docs, that can be generated running `npm run docs` or `yarn docs`.
+Available `options` and details of how use this lib can be found in the docs, that can be generated running `npm run docs` or `yarn docs`.
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "version": "1.0.0",
   "devDependencies": {
     "@naturacosmeticos/eslint-config-natura": "^1.0.0",
-    "chai": "^4.1.2",
     "esdoc": "^1.1.0",
     "esdoc-ecmascript-proposal-plugin": "^1.0.0",
     "esdoc-node": "^1.0.3",
@@ -16,7 +15,8 @@
     "faker": "^4.1.0",
     "husky": "^1.0.0-rc.13",
     "mocha": "^5.2.0",
-    "nyc": "^11.9.0"
+    "nyc": "^11.9.0",
+    "sinon": "^7.1.1"
   },
   "scripts": {
     "docs": "./node_modules/.bin/esdoc -c .esdoc.json",

--- a/src/log-level-filter.js
+++ b/src/log-level-filter.js
@@ -1,0 +1,34 @@
+const {
+  debug, error, warn, log,
+} = require('./levels');
+
+const LOG_LEVEL = Object.freeze([debug, error, warn, log]);
+
+const debugOutput = ({ logLevel, outputType }) => (
+  logLevel === debug && LOG_LEVEL.includes(outputType)
+);
+
+const errorOutput = ({ logLevel, outputType }) => (
+  logLevel === error && LOG_LEVEL.slice(1).includes(outputType)
+);
+
+const warnOutput = ({ logLevel, outputType }) => (
+  logLevel === warn && LOG_LEVEL.slice(2).includes(outputType)
+);
+
+const infoOutput = ({ logLevel, outputType }) => (
+  logLevel === log && outputType === log
+);
+
+module.exports = function logLevelFilter({ logLevel, outputType }) {
+  if (debugOutput({ logLevel, outputType })
+    || errorOutput({ logLevel, outputType })
+    || warnOutput({ logLevel, outputType })
+    || infoOutput({ logLevel, outputType })) {
+    return true;
+  }
+
+  return false;
+};
+
+module.exports.LOG_LEVEL = LOG_LEVEL;

--- a/src/log-level-filter.js
+++ b/src/log-level-filter.js
@@ -2,6 +2,7 @@ const {
   debug, error, warn, log,
 } = require('./levels');
 
+/** @private */
 const LOG_LEVEL = Object.freeze([debug, error, warn, log]);
 
 /** @private */
@@ -21,8 +22,10 @@ const levelOutputMatchers = [
 ];
 
 /** @private */
-module.exports = ({ logLevel, outputType }) => (
-  levelOutputMatchers.some(matcher => matcher({ logLevel, outputType }))
-);
+function logLevelFilter({ logLevel, outputType }) {
+  return levelOutputMatchers.some(matcher => matcher({ logLevel, outputType }));
+}
 
-module.exports.LOG_LEVEL = LOG_LEVEL;
+logLevelFilter.LOG_LEVEL = LOG_LEVEL;
+
+module.exports = logLevelFilter;

--- a/src/log-level-filter.js
+++ b/src/log-level-filter.js
@@ -4,31 +4,25 @@ const {
 
 const LOG_LEVEL = Object.freeze([debug, error, warn, log]);
 
-const debugOutput = ({ logLevel, outputType }) => (
-  logLevel === debug && LOG_LEVEL.includes(outputType)
+/** @private */
+const levelOutputMatchers = [
+  function debugOutput({ logLevel, outputType }) {
+    return logLevel === debug && LOG_LEVEL.includes(outputType);
+  },
+  function errorOutput({ logLevel, outputType }) {
+    return logLevel === error && LOG_LEVEL.slice(1).includes(outputType);
+  },
+  function warnOutput({ logLevel, outputType }) {
+    return logLevel === warn && LOG_LEVEL.slice(2).includes(outputType);
+  },
+  function infoOutput({ logLevel, outputType }) {
+    return logLevel === log && outputType === log;
+  },
+];
+
+/** @private */
+module.exports = ({ logLevel, outputType }) => (
+  levelOutputMatchers.some(matcher => matcher({ logLevel, outputType }))
 );
-
-const errorOutput = ({ logLevel, outputType }) => (
-  logLevel === error && LOG_LEVEL.slice(1).includes(outputType)
-);
-
-const warnOutput = ({ logLevel, outputType }) => (
-  logLevel === warn && LOG_LEVEL.slice(2).includes(outputType)
-);
-
-const infoOutput = ({ logLevel, outputType }) => (
-  logLevel === log && outputType === log
-);
-
-module.exports = function logLevelFilter({ logLevel, outputType }) {
-  if (debugOutput({ logLevel, outputType })
-    || errorOutput({ logLevel, outputType })
-    || warnOutput({ logLevel, outputType })
-    || infoOutput({ logLevel, outputType })) {
-    return true;
-  }
-
-  return false;
-};
 
 module.exports.LOG_LEVEL = LOG_LEVEL;

--- a/src/log-level-filter.js
+++ b/src/log-level-filter.js
@@ -21,7 +21,10 @@ const levelOutputMatchers = [
   },
 ];
 
-/** @private */
+/**
+ * It matches logLevel and outputType and returns if log request
+ * should or should not be logged
+ * @private */
 function logLevelFilter({ logLevel, outputType }) {
   return levelOutputMatchers.some(matcher => matcher({ logLevel, outputType }));
 }

--- a/src/logger.js
+++ b/src/logger.js
@@ -53,7 +53,7 @@ function normalizeArguments(options, extraParameters) {
 const DEFAULT_LOGGER_ATTRIBUTES = {
   logLevel: process.env.LOG_LEVEL || loggerLevels.error,
   logLimit: process.env.LOG_LIMIT || 7000,
-  logPatterns: process.env.LOG_NAMESPACES || '*',
+  logPatterns: process.env.LOG_NAMESPACES || undefined,
   namespace: '',
 };
 
@@ -64,7 +64,7 @@ const DEFAULT_LOGGER_ATTRIBUTES = {
  *  context: { api: 'myAwesomeAPI' }
  *  logLevel: 'error',
  *  logLimit: 7000,
- *  logPatterns: '*',
+ *  logPatterns: '',
  *  namespace: ''
  * });
  *
@@ -73,7 +73,7 @@ const DEFAULT_LOGGER_ATTRIBUTES = {
  * apiLogger.error('Bad request', { errorData })
  */
 class Logger {
-   /**
+  /**
    * Initialize a Logger instance, using prettyjson when LOGS_PRETTY_PRINT is set
    * @param {Object} options - A collection of options
    * @param {Any} [options.context=undefined] - Logger context, accepts any value type
@@ -81,7 +81,7 @@ class Logger {
    * debug, error, warn, log
    * @param {Number} [options.logLimit=7000] - Number in bytes for maximum size of
    * data when using `logLevel:debug`
-   * @param {String} [options.logPatterns='*'] - Pattern to log. `logPatterns: 'api,database'`
+   * @param {String} [options.logPatterns=undefined] - Pattern to log. `logPatterns: 'api,database'`
    * will match and output any log with "api" or "database" in thier namespaces
    *
    * You can also exclude specific debuggers by prefixing them with a "-" character
@@ -98,7 +98,7 @@ class Logger {
    *
    * It will not be possible to use that method on next major release
    */
-   constructor(options, ...extraParameters) {
+  constructor(options, ...extraParameters) {
     const {
       context, namespace, logPatterns, logLimit, logLevel,
     } = normalizeArguments(options, extraParameters);

--- a/src/logger.js
+++ b/src/logger.js
@@ -30,6 +30,8 @@ const prettyPrint = (event) => {
 };
 
 function normalizeArguments(options, extraParameters) {
+  if (!options) return {};
+
   if (!extraParameters.length) return options;
 
   const [namespace, logPatterns, logLimit, logLevel] = extraParameters;
@@ -155,10 +157,6 @@ class Logger {
       logLevelFilter({ logLevel: this.logLevel, outputType }),
       isEnabled(this.namespace, this.logPatterns),
     ].some(response => response !== true);
-  }
-
-  static nonContextualLogger() {
-    return new Logger({});
   }
 
   /**

--- a/test/unit/log-level-filter.js
+++ b/test/unit/log-level-filter.js
@@ -1,0 +1,56 @@
+const assert = require('assert');
+const { lorem } = require('faker');
+
+const logLevelFilter = require('../../src/log-level-filter');
+
+const [DEBUG, ERROR, WARN, LOG] = logLevelFilter.LOG_LEVEL;
+
+describe('Log Level Filter', () => {
+  context('level: debug', () => {
+    it('returns true for every known output type', () => {
+      const levelDebugCheck = outputType => logLevelFilter({ logLevel: DEBUG, outputType });
+
+      assert.strictEqual(logLevelFilter.LOG_LEVEL.every(levelDebugCheck), true);
+    });
+
+    it('returns false if a non-existant output type is requested', () => {
+      assert.strictEqual(logLevelFilter({ logLevel: DEBUG, outputType: lorem.word() }), false);
+    });
+  });
+
+  context('level: error', () => {
+    it('returns false when output type is debug', () => {
+      assert.strictEqual(logLevelFilter({ logLevel: ERROR, outputType: DEBUG }), false);
+    });
+
+    it('returns true for error, warn and info output types', () => {
+      const levelErrorCheck = outputType => logLevelFilter({ logLevel: ERROR, outputType });
+
+      assert.strictEqual([ERROR, WARN, LOG].every(levelErrorCheck), true);
+    });
+  });
+
+  context('level: warn', () => {
+    const levelWarnCheck = outputType => logLevelFilter({ logLevel: WARN, outputType });
+
+    it('retuns false for debug and error output types', () => {
+      assert.strictEqual([DEBUG, ERROR].every(levelWarnCheck), false);
+    });
+
+    it('returns true for warn and info output types', () => {
+      assert.strictEqual([WARN, LOG].every(levelWarnCheck), true);
+    });
+  });
+
+  context('level: info', () => {
+    const levelInfoCheck = outputType => logLevelFilter({ logLevel: LOG, outputType });
+
+    it('returns false for every type but info', () => {
+      assert.strictEqual([DEBUG, ERROR, WARN].every(levelInfoCheck), false);
+    });
+
+    it('returns true when info output type is requested', () => {
+      assert.strictEqual(logLevelFilter({ logLevel: LOG, outputType: LOG }), true);
+    });
+  });
+});

--- a/test/unit/log-level-filter.js
+++ b/test/unit/log-level-filter.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const { lorem } = require('faker');
 
 const logLevelFilter = require('../../src/log-level-filter');
@@ -10,23 +10,23 @@ describe('Log Level Filter', () => {
     it('returns true for every known output type', () => {
       const levelDebugCheck = outputType => logLevelFilter({ logLevel: DEBUG, outputType });
 
-      assert.strictEqual(logLevelFilter.LOG_LEVEL.every(levelDebugCheck), true);
+      assert.equal(logLevelFilter.LOG_LEVEL.every(levelDebugCheck), true);
     });
 
     it('returns false if a non-existant output type is requested', () => {
-      assert.strictEqual(logLevelFilter({ logLevel: DEBUG, outputType: lorem.word() }), false);
+      assert.equal(logLevelFilter({ logLevel: DEBUG, outputType: lorem.word() }), false);
     });
   });
 
   context('level: error', () => {
     it('returns false when output type is debug', () => {
-      assert.strictEqual(logLevelFilter({ logLevel: ERROR, outputType: DEBUG }), false);
+      assert.equal(logLevelFilter({ logLevel: ERROR, outputType: DEBUG }), false);
     });
 
     it('returns true for error, warn and info output types', () => {
       const levelErrorCheck = outputType => logLevelFilter({ logLevel: ERROR, outputType });
 
-      assert.strictEqual([ERROR, WARN, LOG].every(levelErrorCheck), true);
+      assert.equal([ERROR, WARN, LOG].every(levelErrorCheck), true);
     });
   });
 
@@ -34,11 +34,11 @@ describe('Log Level Filter', () => {
     const levelWarnCheck = outputType => logLevelFilter({ logLevel: WARN, outputType });
 
     it('retuns false for debug and error output types', () => {
-      assert.strictEqual([DEBUG, ERROR].every(levelWarnCheck), false);
+      assert.equal([DEBUG, ERROR].every(levelWarnCheck), false);
     });
 
     it('returns true for warn and info output types', () => {
-      assert.strictEqual([WARN, LOG].every(levelWarnCheck), true);
+      assert.equal([WARN, LOG].every(levelWarnCheck), true);
     });
   });
 
@@ -46,11 +46,11 @@ describe('Log Level Filter', () => {
     const levelInfoCheck = outputType => logLevelFilter({ logLevel: LOG, outputType });
 
     it('returns false for every type but info', () => {
-      assert.strictEqual([DEBUG, ERROR, WARN].every(levelInfoCheck), false);
+      assert.equal([DEBUG, ERROR, WARN].every(levelInfoCheck), false);
     });
 
     it('returns true when info output type is requested', () => {
-      assert.strictEqual(logLevelFilter({ logLevel: LOG, outputType: LOG }), true);
+      assert.equal(logLevelFilter({ logLevel: LOG, outputType: LOG }), true);
     });
   });
 });

--- a/test/unit/logger.js
+++ b/test/unit/logger.js
@@ -1,0 +1,53 @@
+const assert = require('assert').strict;
+const { spy } = require('sinon');
+const { lorem } = require('faker');
+
+const Logger = require('../../src/logger');
+const loggerLevels = require('../../src/levels');
+
+// TODO: Make it better
+// TODO: Cover missing functions
+
+describe('Logger', () => {
+  context('supressing output via log level', () => {
+    function createLoggerWithLogLevel(logLevel) {
+      const logger = new Logger({}, '', '*', 7000, logLevel);
+
+      return [logger, spy(logger, 'format')];
+    }
+
+    const loggerMethods = ['debug', 'error', 'warn', 'info'];
+
+    it('does not supress any calls', () => {
+      const [debugLevelLogger, loggerFormatSpy] = createLoggerWithLogLevel(loggerLevels.debug);
+
+      loggerMethods.forEach(method => debugLevelLogger[method](lorem.sentence()));
+
+      assert.equal(loggerFormatSpy.callCount, 4);
+    });
+
+    it('supresses debug calls', () => {
+      const [errorLevelLogger, loggerFormatSpy] = createLoggerWithLogLevel(loggerLevels.error);
+
+      loggerMethods.forEach(method => errorLevelLogger[method](lorem.sentence()));
+
+      assert.equal(loggerFormatSpy.callCount, 3);
+    });
+
+    it('supresses debug and error calls', () => {
+      const [errorLevelLogger, loggerFormatSpy] = createLoggerWithLogLevel(loggerLevels.warn);
+
+      loggerMethods.forEach(method => errorLevelLogger[method](lorem.sentence()));
+
+      assert.equal(loggerFormatSpy.callCount, 2);
+    });
+
+    it('supresses all but log/info calls', () => {
+      const [infoLevelLogger, loggerFormatSpy] = createLoggerWithLogLevel(loggerLevels.log);
+
+      loggerMethods.forEach(method => infoLevelLogger[method](lorem.sentence()));
+
+      assert.equal(loggerFormatSpy.callCount, 1);
+    });
+  });
+});

--- a/test/unit/logger.js
+++ b/test/unit/logger.js
@@ -1,12 +1,22 @@
 const assert = require('assert').strict;
 const { spy } = require('sinon');
-const { lorem } = require('faker');
+const { lorem, random } = require('faker');
 
 const Logger = require('../../src/logger');
 const loggerLevels = require('../../src/levels');
 
 // TODO: Make it better
 // TODO: Cover missing functions
+
+function generateLoggerAttributes() {
+  return {
+    loggerContext: lorem.word(),
+    loggerLogLevel: random.objectElement(loggerLevels),
+    loggerLogLimit: random.number(),
+    loggerNamespace: lorem.word(),
+    loggerPattern: lorem.word(),
+  };
+}
 
 describe('Logger', () => {
   context('supressing output via log level', () => {
@@ -49,5 +59,53 @@ describe('Logger', () => {
 
       assert.equal(loggerFormatSpy.callCount, 1);
     });
+  });
+
+  it('creates an instance of logger using legacy mode', () => {
+    const {
+      loggerContext,
+      loggerLogLevel,
+      loggerLogLimit,
+      loggerNamespace,
+      loggerPattern,
+    } = generateLoggerAttributes();
+
+    const legacyLogger = new Logger(
+      loggerContext,
+      loggerNamespace,
+      loggerPattern,
+      loggerLogLimit,
+      loggerLogLevel,
+    );
+
+    it('has correct context', () => assert.equal(legacyLogger.contextData.context, loggerContext));
+    it('has correct logLevel', () => assert.equal(legacyLogger.logLevel, loggerLogLevel));
+    it('has correct logLimit', () => assert.equal(legacyLogger.logLimit, loggerLogLimit));
+    it('has correct logPatterns', () => assert.equal(legacyLogger.logPatterns, loggerPattern));
+    it('has correct namespace', () => assert.equal(legacyLogger.namespace, loggerNamespace));
+  });
+
+  it('creates an instance of logger using object options mode', () => {
+    const {
+      loggerContext,
+      loggerLogLevel,
+      loggerLogLimit,
+      loggerNamespace,
+      loggerPattern,
+    } = generateLoggerAttributes();
+
+    const logger = new Logger({
+      context: loggerContext,
+      logLevel: loggerLogLevel,
+      logLimit: loggerLogLimit,
+      logPatterns: loggerPattern,
+      namespace: loggerNamespace,
+    });
+
+    it('has correct context', () => assert.equal(logger.contextData.context, loggerContext));
+    it('has correct logLevel', () => assert.equal(logger.logLevel, loggerLogLevel));
+    it('has correct logLimit', () => assert.equal(logger.logLimit, loggerLogLimit));
+    it('has correct logPatterns', () => assert.equal(logger.logPatterns, loggerPattern));
+    it('has correct namespace', () => assert.equal(logger.namespace, loggerNamespace));
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,6 +26,32 @@
     eslint "^5.7.0"
     eslint-config-airbnb-base "^13.1.0"
 
+"@sinonjs/commons@^1.2.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.3.0.tgz#50a2754016b6f30a994ceda6d9a0a8c36adda849"
+  integrity sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@3.0.0", "@sinonjs/formatio@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.0.0.tgz#9d282d81030a03a03fa0c5ce31fd8786a4da311a"
+  integrity sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==
+  dependencies:
+    "@sinonjs/samsam" "2.1.0"
+
+"@sinonjs/samsam@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.1.0.tgz#b8b8f5b819605bd63601a6ede459156880f38ea3"
+  integrity sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==
+  dependencies:
+    array-from "^2.1.1"
+
+"@sinonjs/samsam@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.1.2.tgz#16947fce5f57258d01f1688fdc32723093c55d3f"
+  integrity sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw==
+
 "@types/node@*":
   version "10.12.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.2.tgz#d77f9faa027cadad9c912cd47f4f8b07b0fb0864"
@@ -146,6 +172,11 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
+
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -184,11 +215,6 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
-
-assertion-error@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
-  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 assign-symbols@^1.0.0:
   version "1.0.0"
@@ -445,18 +471,6 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chai@^4.1.2:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
-  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
-  dependencies:
-    assertion-error "^1.1.0"
-    check-error "^1.0.2"
-    deep-eql "^3.0.1"
-    get-func-name "^2.0.0"
-    pathval "^1.1.0"
-    type-detect "^4.0.5"
-
 chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -481,11 +495,6 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
-
-check-error@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
-  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 cheerio@0.20.0:
   version "0.20.0"
@@ -788,13 +797,6 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
-deep-eql@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
-  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
-  dependencies:
-    type-detect "^4.0.0"
-
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -869,7 +871,7 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-diff@3.5.0:
+diff@3.5.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -1581,11 +1583,6 @@ get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
-
-get-func-name@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
-  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -2327,6 +2324,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+just-extend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-3.0.0.tgz#cee004031eaabf6406da03a7b84e4fe9d78ef288"
+  integrity sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -2440,6 +2442,11 @@ lodash.foreach@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
   integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
 lodash.map@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
@@ -2474,6 +2481,16 @@ lodash@^4.1.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, 
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+lolex@^2.3.2:
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
+  integrity sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
+
+lolex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.0.0.tgz#f04ee1a8aa13f60f1abd7b0e8f4213ec72ec193e"
+  integrity sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -2688,6 +2705,17 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+nise@^1.4.6:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.6.tgz#76cc3915925056ae6c405dd8ad5d12bde570c19f"
+  integrity sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==
+  dependencies:
+    "@sinonjs/formatio" "3.0.0"
+    just-extend "^3.0.0"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 normalize-package-data@^2.3.2:
   version "2.4.0"
@@ -3011,6 +3039,13 @@ path-parse@^1.0.5:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -3026,11 +3061,6 @@ path-type@^2.0.0:
   integrity sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=
   dependencies:
     pify "^2.0.0"
-
-pathval@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
-  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -3442,6 +3472,21 @@ signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
+sinon@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.1.1.tgz#1202f317aa14d93cb9b69ff50b6bd49c0e05ffc9"
+  integrity sha512-iYagtjLVt1vN3zZY7D8oH7dkjNJEjLjyuzy8daX5+3bbQl8gaohrheB9VfH1O3L6LKuue5WTJvFluHiuZ9y3nQ==
+  dependencies:
+    "@sinonjs/commons" "^1.2.0"
+    "@sinonjs/formatio" "^3.0.0"
+    "@sinonjs/samsam" "^2.1.2"
+    diff "^3.5.0"
+    lodash.get "^4.4.2"
+    lolex "^3.0.0"
+    nise "^1.4.6"
+    supports-color "^5.5.0"
+    type-detect "^4.0.8"
+
 slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
@@ -3672,7 +3717,7 @@ supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -3714,6 +3759,11 @@ test-exclude@^4.2.0:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
+
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+  integrity sha1-45mpgiV6J22uQou5KEXLcb3CbRk=
 
 text-table@^0.2.0:
   version "0.2.0"
@@ -3804,7 +3854,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
We should be able to filter logs via log level.

Removed chai from dependencies as we're only using node's assert.

Including sinon to spy format function on Logger class

Changing Logger class to accept an object options deprecating parameters mode
  There are 2 reason for it:
    - our lint does not allow to create a function with 5 parameters
    - It does not give us flexibility to define just one of them.

We're still able to create using parameters instead options, but it should be removed soon.

Updating esDocs and readme to match new Logger signature