### PR TITLE
Returning false is no enabledNamespaces is given

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "index.js",
   "name": "@naturacosmeticos/clio-nodejs-logger",
   "author": "Natura Cosméticos <TDDAArquitetura@natura.net>",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "devDependencies": {
     "@naturacosmeticos/eslint-config-natura": "^1.0.0",
     "esdoc": "^1.1.0",

--- a/src/is-enabled.js
+++ b/src/is-enabled.js
@@ -21,6 +21,8 @@ function createPatterns({ excludingPatterns, includingPatterns }, nextPattern) {
 
 /** @private */
 module.exports = (namespace, enabledNamespaces) => {
+  if (!enabledNamespaces) return false;
+
   const { excludingPatterns, includingPatterns } = enabledNamespaces
     .split(',')
     .reduce(createPatterns, { excludingPatterns: [], includingPatterns: [] });

--- a/test/unit/is-enabled.js
+++ b/test/unit/is-enabled.js
@@ -10,7 +10,6 @@ describe('Log Enable', () => {
   context('with an * pattern', () => {
     it('enables all logs', () => {
       assert.ok(isEnabled(faker.random.words(), '*'));
-      assert.ok(isEnabled(faker.random.words(), '*'));
     });
 
     context('and an exclude pattern', () => {

--- a/test/unit/is-enabled.js
+++ b/test/unit/is-enabled.js
@@ -79,4 +79,12 @@ describe('Log Enable', () => {
       assert.ok(namespaces.every(ns => !isEnabled(ns, enabledNamespaces)));
     });
   });
+
+  context('with an undefined pattern', () => {
+    it('disables all messages', () => {
+      const namespace = faker.lorem.word();
+
+      assert.strictEqual(isEnabled(namespace), false);
+    });
+  });
 });


### PR DESCRIPTION
chore: Deleting duplicated line

chore: create exclude and include pattern at once

Using `reduce` to create **excludePatterns** and **includingPatterns** with only
one array iteration.

Saving excludingPatterns without "-" (minus) character to reutilize
`match` function.

Renaming `match` function to `matchPattern` to describe itself better