### PR TITLE
Wrong behavior of object options mode properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "index.js",
   "name": "@naturacosmeticos/clio-nodejs-logger",
   "author": "Natura Cosméticos <TDDAArquitetura@natura.net>",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "devDependencies": {
     "@naturacosmeticos/eslint-config-natura": "^1.0.0",
     "esdoc": "^1.1.0",

--- a/src/logger.js
+++ b/src/logger.js
@@ -29,11 +29,22 @@ const prettyPrint = (event) => {
   return `\n${header}\n\t${body}\n\n`;
 };
 
+/**
+ * default values for Logger instance
+ * @private
+ */
+const DEFAULT_LOGGER_ATTRIBUTES = {
+  logLevel: process.env.LOG_LEVEL || loggerLevels.error,
+  logLimit: process.env.LOG_LIMIT || 7000,
+  logPatterns: process.env.LOG_NAMESPACES || undefined,
+  namespace: '',
+};
+
 /** @private */
 function normalizeArguments(options, extraParameters) {
   if (!options) return {};
 
-  if (!extraParameters.length) return options;
+  if (!extraParameters.length) return Object.assign({}, DEFAULT_LOGGER_ATTRIBUTES, options);
 
   const [namespace, logPatterns, logLimit, logLevel] = extraParameters;
 
@@ -45,17 +56,6 @@ function normalizeArguments(options, extraParameters) {
     namespace,
   };
 }
-
-/**
- * default values for Logger instance
- * @private
- */
-const DEFAULT_LOGGER_ATTRIBUTES = {
-  logLevel: process.env.LOG_LEVEL || loggerLevels.error,
-  logLimit: process.env.LOG_LIMIT || 7000,
-  logPatterns: process.env.LOG_NAMESPACES || undefined,
-  namespace: '',
-};
 
 /**
  * Basic Logger usage
@@ -103,7 +103,7 @@ class Logger {
       context, namespace, logPatterns, logLimit, logLevel,
     } = normalizeArguments(options, extraParameters);
 
-    Object.assign(this, DEFAULT_LOGGER_ATTRIBUTES, {
+    Object.assign(this, {
       contextData: { context, name: process.env.APP_NAME },
       format: process.env.LOGS_PRETTY_PRINT ? prettyPrint : stringify,
       log: this.info,
@@ -187,7 +187,7 @@ class Logger {
 
   /** @private */
   output(message, additionalArguments, outputType = loggerLevels.log) {
-    if (this.shouldSupressOutput(outputType)) return;
+    if (this.shouldSuppressOutput(outputType)) return;
 
     const event = this.serializer.serialize(
       message, additionalArguments, outputType,
@@ -197,7 +197,7 @@ class Logger {
   }
 
   /** @private */
-  shouldSupressOutput(outputType) {
+  shouldSuppressOutput(outputType) {
     return [
       logLevelFilter({ logLevel: this.logLevel, outputType }),
       isEnabled(this.namespace, this.logPatterns),

--- a/test/unit/logger.js
+++ b/test/unit/logger.js
@@ -20,16 +20,22 @@ function generateLoggerAttributes() {
 }
 
 describe('Logger', () => {
-  context('supressing output via log level', () => {
+  context('suppressing output via log level', () => {
     function createLoggerWithLogLevel(logLevel) {
-      const logger = new Logger({}, '', '*', 7000, logLevel);
+      const logger = new Logger({
+        context: {},
+        logLevel,
+        logLimit: 7000,
+        logPatterns: '*',
+        namespace: '',
+      });
 
       return [logger, spy(logger, 'format')];
     }
 
     const loggerMethods = ['debug', 'error', 'warn', 'info'];
 
-    it('does not supress any calls', () => {
+    it('does not suppress any calls', () => {
       const [debugLevelLogger, loggerFormatSpy] = createLoggerWithLogLevel(loggerLevels.debug);
 
       loggerMethods.forEach(method => debugLevelLogger[method](lorem.sentence()));
@@ -37,7 +43,7 @@ describe('Logger', () => {
       assert.equal(loggerFormatSpy.callCount, 4);
     });
 
-    it('supresses debug calls', () => {
+    it('suppresses debug calls', () => {
       const [errorLevelLogger, loggerFormatSpy] = createLoggerWithLogLevel(loggerLevels.error);
 
       loggerMethods.forEach(method => errorLevelLogger[method](lorem.sentence()));
@@ -45,7 +51,15 @@ describe('Logger', () => {
       assert.equal(loggerFormatSpy.callCount, 3);
     });
 
-    it('supresses debug and error calls', () => {
+    it('suppresses as log level error if only logPattern is given', () => {
+      const logger = new Logger({ logPatterns: '*' });
+      const loggerFormatSpy = spy(logger, 'format');
+
+      loggerMethods.forEach(method => logger[method](lorem.sentence()));
+      assert.equal(loggerFormatSpy.callCount, 3);
+    });
+
+    it('suppresses debug and error calls', () => {
       const [errorLevelLogger, loggerFormatSpy] = createLoggerWithLogLevel(loggerLevels.warn);
 
       loggerMethods.forEach(method => errorLevelLogger[method](lorem.sentence()));
@@ -53,7 +67,7 @@ describe('Logger', () => {
       assert.equal(loggerFormatSpy.callCount, 2);
     });
 
-    it('supresses all but log/info calls', () => {
+    it('suppresses all but log/info calls', () => {
       const [infoLevelLogger, loggerFormatSpy] = createLoggerWithLogLevel(loggerLevels.log);
 
       loggerMethods.forEach(method => infoLevelLogger[method](lorem.sentence()));


### PR DESCRIPTION
Fixed typo on all suppress strigns/method name. Supress -> Suppress

Fixed behavior when creating instance with object options, undefined
propertiers were overwriting default values.

Creating a test assert for cases with only logPattern is given to
instance
 - instances without logPattern will always suppress. Since there is no
match for them